### PR TITLE
Change Promise async action wrapper API: introduce `PromiseResolver`

### DIFF
--- a/Promise.xcodeproj/project.pbxproj
+++ b/Promise.xcodeproj/project.pbxproj
@@ -87,7 +87,7 @@
 		A57655921F16CE3A0085B45C /* PromiseTests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "PromiseTests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A57655971F16CE3A0085B45C /* PromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromiseTests.swift; sourceTree = "<group>"; };
 		A57655991F16CE3A0085B45C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A57655A31F16CE6F0085B45C /* PromiseCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseCore.swift; sourceTree = "<group>"; };
+		A57655A31F16CE6F0085B45C /* PromiseCore.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = PromiseCore.swift; sourceTree = "<group>"; tabWidth = 2; };
 		A57655A51F16CE850085B45C /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		A57655A71F16CE950085B45C /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		A57655A91F16CECF0085B45C /* PromiseMonadic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromiseMonadic.swift; sourceTree = "<group>"; };

--- a/Promise/PromiseExtension.swift
+++ b/Promise/PromiseExtension.swift
@@ -11,18 +11,18 @@ import Foundation
 extension Promise {
     
     public func completeOn(queue: DispatchQueue) -> Promise {
-        return Promise { complete, _ in
+        return Promise { resolver in
             self.whenComplete { result in
-                queue.async { complete(result) }
+                queue.async { resolver.complete(result) }
             }
         }
     }
     
     public func delayed(for delay: DispatchTimeInterval, on queue: DispatchQueue = DispatchQueue.main) -> Promise {
-        return Promise { complete, _ in
+        return Promise { resolver in
             self.whenComplete { result in
                 queue.asyncAfter(deadline: .now() + delay) {
-                    complete(result)
+                    resolver.complete(result)
                 }
             }
         }

--- a/Promise/PromiseMonadic.swift
+++ b/Promise/PromiseMonadic.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Promise {
     
     private func commonThen<T1, E1: Error>(transform: @escaping (Result<T, E>) -> Promise<T1, E1>) -> Promise<T1, E1> {
-        return Promise<T1, E1> { complete, cancel in
+        return Promise<T1, E1> { resolver in
             let serialQueue = DispatchQueue(label: "serialiazation")
             
             var innerCancel: PromiseCancelFunction = {}
@@ -24,10 +24,10 @@ extension Promise {
                 
                 let innerPromise = transform(result)
                 serialQueue.sync { innerCancel = innerPromise.cancel }
-                innerPromise.whenComplete(callback: complete)
+                innerPromise.whenComplete(callback: resolver.complete)
                 
             }
-            cancel = {
+            resolver.onCancel = {
                 serialQueue.sync {
                     cancelled = true
                     innerCancel()

--- a/Promise/PromiseNoError.swift
+++ b/Promise/PromiseNoError.swift
@@ -37,6 +37,6 @@ extension Promise {
     }
     
     public static func never() -> Promise {
-        return Promise {_, _ in }
+        return Promise {_ in }
     }
 }

--- a/Promise/PromiseSideEffects.swift
+++ b/Promise/PromiseSideEffects.swift
@@ -12,20 +12,20 @@ import Foundation
 extension Promise {
     
     public func onStart(do action: @escaping () -> Void) -> Promise {
-        return Promise { complete, cancel in
+        return Promise { resolver in
             action()
-            self.whenComplete(callback: complete)
-            cancel = { self.cancel() }
+            self.whenComplete(callback: resolver.complete)
+            resolver.onCancel = { self.cancel() }
         }
     }
     
     public func onComplete(do action: @escaping (Result<T, E>) -> Void) -> Promise {
-        return Promise { complete, cancel in
+        return Promise { resolver in
             self.whenComplete { result in
                 action(result)
-                complete(result)
+                resolver.complete(result)
             }
-            cancel = { self.cancel() }
+            resolver.onCancel = { self.cancel() }
         }
     }
     

--- a/PromiseTests/PromiseTests.swift
+++ b/PromiseTests/PromiseTests.swift
@@ -43,9 +43,9 @@ extension Array where Element: Equatable {
 }
 
 func makeAsyncPromise<V>(result: Result<V, TestError>, delay: DispatchTimeInterval) -> Promise<V, TestError> {
-    return Promise<V, TestError> { complete, _ in
+    return Promise<V, TestError> { resolver in
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            complete(result)
+            resolver.complete(result)
         }
     }
 }
@@ -131,8 +131,8 @@ class PromiseTests: XCTestCase {
     
     func testCancellablePromiseCancel() {
         var cancelled = false
-        let promise = Promise<Void, TestError> { complete, cancel in
-            cancel = { cancelled = true }
+        let promise = Promise<Void, TestError> { resolver in
+            resolver.onCancel = { cancelled = true }
         }
         
         //start
@@ -240,8 +240,8 @@ class PromiseTests: XCTestCase {
     
     func testPromiseAllCancelOnFail() {
         let exp = expectation(description: "cancelled called")
-        let successPromise = Promise<Int, TestError> {_, cancel in
-            cancel = {
+        let successPromise = Promise<Int, TestError> { resolver in
+            resolver.onCancel = {
                 exp.fulfill()
             }
         }


### PR DESCRIPTION
As per comments in https://github.com/Shopify/promise-swift/issues/2#issuecomment-320014668, avoid using `inout`parameter for providing cancellation action when creating `Promise`, use resolver instead.