### PR TITLE
Fix potential deadlock reason

### DIFF
--- a/Promise/Atomic.swift
+++ b/Promise/Atomic.swift
@@ -29,8 +29,8 @@ final class Atomic<Value> {
     let oldValue = _value
     lock.lock()
     defer {
-      didSetCallback?(oldValue, _value)
       lock.unlock()
+      didSetCallback?(oldValue, _value)
     }
     
     return try action(&_value)


### PR DESCRIPTION
Promise can deadlock because atomic's didSet callback is being set _under_ locked section, which means modifying state in that callback will cause deadlock.